### PR TITLE
Reinstate simplified gating logic

### DIFF
--- a/server/hook.go
+++ b/server/hook.go
@@ -177,14 +177,14 @@ func PostHook(c *gin.Context) {
 		return
 	}
 
-	if repo.IsGated { // This feature is not clear to me. Reenabling once better understood
-		build.Status = model.StatusBlocked
-	}
-
 	// update some build fields
 	build.RepoID = repo.ID
 	build.Verified = true
 	build.Status = model.StatusPending
+
+	if repo.IsGated && build.Sender != user.Login {
+		build.Status = model.StatusBlocked
+	}
 
 	err = store.CreateBuild(c, build, build.Procs...)
 	if err != nil {


### PR DESCRIPTION
The gating feature was disabled when multi-pipes were introduced. Partly deliberately, partly as a bug.

This PR enables it in a simpler form: if the repo is gated, all builds started by changes not by the repo author has to be manually approved.

#42 

TODO:
- [ ] Document using it for an opensource project
- [ ] Write test for gating