### PR TITLE
Handle transitive deps: queue knows about skipped tasks now

### DIFF
--- a/cncd/queue/queue.go
+++ b/cncd/queue/queue.go
@@ -27,8 +27,8 @@ type Task struct {
 	// Task IDs this task depend
 	Dependencies []string
 
-	// If dep finished sucessfully
-	DepStatus map[string]bool
+	// Dependency's exit status
+	DepStatus map[string]string
 
 	// RunOn failure or success
 	RunOn []string
@@ -41,8 +41,8 @@ func (t *Task) ShouldRun() bool {
 	}
 
 	if !runsOnFailure(t.RunOn) && runsOnSuccess(t.RunOn) {
-		for _, success := range t.DepStatus {
-			if !success {
+		for _, status := range t.DepStatus {
+			if StatusSuccess != status {
 				return false
 			}
 		}
@@ -50,8 +50,8 @@ func (t *Task) ShouldRun() bool {
 	}
 
 	if runsOnFailure(t.RunOn) && !runsOnSuccess(t.RunOn) {
-		for _, success := range t.DepStatus {
-			if success {
+		for _, status := range t.DepStatus {
+			if StatusSuccess == status {
 				return false
 			}
 		}
@@ -118,7 +118,7 @@ type Queue interface {
 	Extend(c context.Context, id string) error
 
 	// Done signals the task is complete.
-	Done(c context.Context, id string) error
+	Done(c context.Context, exitStatus string, id string) error
 
 	// Error signals the task is complete with errors.
 	Error(c context.Context, id string, err error) error

--- a/model/queue.go
+++ b/model/queue.go
@@ -49,7 +49,7 @@ func WithTaskStore(q queue.Queue, s TaskStore) queue.Queue {
 			Labels:       task.Labels,
 			Dependencies: task.Dependencies,
 			RunOn:        task.RunOn,
-			DepStatus:    make(map[string]bool),
+			DepStatus:    make(map[string]string),
 		})
 	}
 	q.PushAtOnce(context.Background(), toEnqueue)

--- a/server/hook.go
+++ b/server/hook.go
@@ -388,7 +388,7 @@ func queueBuild(build *model.Build, repo *model.Repo, buildItems []*buildItem) {
 		task.Labels["repo"] = repo.FullName
 		task.Dependencies = taskIds(item.DependsOn, buildItems)
 		task.RunOn = item.RunsOn
-		task.DepStatus = make(map[string]bool)
+		task.DepStatus = make(map[string]string)
 
 		task.Data, _ = json.Marshal(rpc.Pipeline{
 			ID:      fmt.Sprint(item.Proc.ID),

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -384,7 +384,7 @@ func (s *RPC) Done(c context.Context, id string, state rpc.State) error {
 	if proc.Failing() {
 		queueErr = s.queue.Error(c, id, fmt.Errorf("Proc finished with exitcode %d, %s", state.ExitCode, state.Error))
 	} else {
-		queueErr = s.queue.Done(c, id)
+		queueErr = s.queue.Done(c, id, proc.State)
 	}
 	if queueErr != nil {
 		log.Printf("error: done: cannot ack proc_id %d: %s", procID, err)


### PR DESCRIPTION
Multi-pipeline dependencies didn't handle well the transitive cases.

Given a pipeline where the dependency tree is the following: A => B => C
If C fails, B was correctly set to skipped status, but A still ran.

This PR fixes the situation and in the above case A will be set to skipped as well.